### PR TITLE
Add optional flat field correction to NIRSpec pipeline

### DIFF
--- a/construct_flat_field.py
+++ b/construct_flat_field.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 import datetime
 import math
@@ -265,9 +265,6 @@ def calculate_pixel_ratios(
 def do_tile(
     paths: list[str],
     path_out: str,
-    channel: str,
-    band: str,
-    fringe: str,
     dataset: str,
     *,
     lat_bin_size_factor: float = 1.25,
@@ -278,14 +275,27 @@ def do_tile(
     sigma_iterations: int = 5,
     snr_threshold: float = 10,
     max_correction: float = 1.5,
+    channel: str | None = None,  # MIRI metadata
+    band: str | None = None,
+    fringe: str | None = None,
+    filter: str | None = None,  # NIRSpec metadata
+    grating: str | None = None,
 ):
     header = fits.Header()
     header[f'HIERARCH {HEADER_PREFIX} VERSION'] = (__version__, 'Software version')
     header[f'HIERARCH {HEADER_PREFIX} DATE'] = datetime.datetime.now().isoformat()
     header[f'HIERARCH {HEADER_PREFIX} DATASET'] = dataset
-    header[f'HIERARCH {HEADER_PREFIX} CHANNEL'] = channel
-    header[f'HIERARCH {HEADER_PREFIX} BAND'] = band
-    header[f'HIERARCH {HEADER_PREFIX} DEFRINGED'] = bool(fringe)
+
+    if channel is not None:
+        header[f'HIERARCH {HEADER_PREFIX} CHANNEL'] = channel
+    if band is not None:
+        header[f'HIERARCH {HEADER_PREFIX} BAND'] = band
+    if fringe is not None:
+        header[f'HIERARCH {HEADER_PREFIX} DEFRINGED'] = bool(fringe)
+    if filter is not None:
+        header[f'HIERARCH {HEADER_PREFIX} FILTER'] = filter
+    if grating is not None:
+        header[f'HIERARCH {HEADER_PREFIX} GRATING'] = grating
 
     flat_cube = construct_flat_cube(
         paths,

--- a/construct_flat_field.py
+++ b/construct_flat_field.py
@@ -278,7 +278,7 @@ def do_tile(
     channel: str | None = None,  # MIRI metadata
     band: str | None = None,
     fringe: str | None = None,
-    filter: str | None = None,  # NIRSpec metadata
+    filter_: str | None = None,  # NIRSpec metadata
     grating: str | None = None,
 ):
     header = fits.Header()
@@ -292,8 +292,8 @@ def do_tile(
         header[f'HIERARCH {HEADER_PREFIX} BAND'] = band
     if fringe is not None:
         header[f'HIERARCH {HEADER_PREFIX} DEFRINGED'] = bool(fringe)
-    if filter is not None:
-        header[f'HIERARCH {HEADER_PREFIX} FILTER'] = filter
+    if filter_ is not None:
+        header[f'HIERARCH {HEADER_PREFIX} FILTER'] = filter_
     if grating is not None:
         header[f'HIERARCH {HEADER_PREFIX} GRATING'] = grating
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -54,11 +54,11 @@ Step: TypeAlias = Literal[
     'navigate',
     'desaturate',
     'despike',
+    'flat',
     'plot',
     'animate',
     'defringe_1d',  # MIRI only
     'psf',  # MIRI only
-    'flat',  # MIRI only
     'defringe',  # MIRI only
 ]
 BoolOrBoth: TypeAlias = Literal[True, False, 'both']


### PR DESCRIPTION
This is basically identical to the MIRI pipeline's flat fielding, with appropriate channel/band -> filter/grating translations. This currently runs right at the end of the reduction chain for NIRSpec to allow easy bolting-on to existing reductions, though this may be something we would want to look at in the future.

As it stands, all the defaults are identical to the MIRI values (this is mainly relevant in `construct_flat_field`), but may want some adjustment in the future with testing on real data.